### PR TITLE
Update iam.tf

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -16,7 +16,7 @@ resource "aws_iam_role" "ecs_agent" {
 
 
 resource "aws_iam_role_policy_attachment" "ecs_agent" {
-  role       = "aws_iam_role.ecs_agent"
+  role       = aws_iam_role.ecs_agent.name
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role"
 }
 resource "aws_iam_instance_profile" "ecs_agent" {


### PR DESCRIPTION
`role` in `aws_iam_role_policy_attachment` should refer the `name` of `aws_iam_role.ecs_agent`